### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/src/core/server/http/http_handler.py
+++ b/src/core/server/http/http_handler.py
@@ -9,7 +9,7 @@ License: MIT
 
 # Third-party imports
 from tornado.ioloop import IOLoop
-
+import logging
 # Local application imports
 from core.worker import Worker
 from core.server.base_handler import BaseHandler, workers, recycle
@@ -60,7 +60,8 @@ class HttpHandler(BaseHandler):
             # Create a new worker to pair HTTP connection with websocket session
             worker = self.create_worker()
         except Exception as e:
-            status = str(e)
+            logging.exception("Error creating worker in HttpHandler.post")
+            status = "Internal server error"
         else:
             # Add the worker to the worker registry
             worker_id = worker.id


### PR DESCRIPTION
Potential fix for [https://github.com/sentrychris/psmonitor/security/code-scanning/2](https://github.com/sentrychris/psmonitor/security/code-scanning/2)

To fix the problem, we should avoid returning raw exception messages to the client. Instead, we should log the details of the exception on the server (for debugging and audit purposes), and return a generic, non-sensitive error message to the client. This can be achieved by:

- Importing the standard library `logging` module.
- Logging the caught exception with traceback information using `logging.exception()` within the exception handler.
- Returning a generic error message (e.g., "Internal server error") in the `status` field of the JSON response.

The changes will be made in `src/core/server/http/http_handler.py`, specifically in the `post` method of the `HttpHandler` class. The import for `logging` will be added if not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
